### PR TITLE
Fixed the transform destination surface incompatibility problem in some devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+base_classes/__pycache__
+game_elements/__pycache__
+helper/__pycache__
+.idea

--- a/gamemanager.py
+++ b/gamemanager.py
@@ -9,6 +9,7 @@ from scenes import MainMenu, Game
 class GameManager:
     def __init__(self):
         self.current_scene = MainMenu(self) # Set initial scene
+        self.failed_fast_transform = False
 
     def run(self):
         prev_frame_time = time.perf_counter()
@@ -38,7 +39,19 @@ class GameManager:
             self.current_scene.render(game_surface)
 
             # Draw surfaces to window
-            pygame.transform.scale(game_surface, (WINDOW_WIDTH, WINDOW_HEIGHT), window)
+
+            if not self.failed_fast_transform:
+                try:
+                    pygame.transform.scale(game_surface, (WINDOW_WIDTH, WINDOW_HEIGHT), window)
+                except pygame.error:
+                    print("The size and depth of game_surface and window don't match!")
+                    self.failed_fast_transform = True
+
+            if self.failed_fast_transform:
+                mid_surface = pygame.transform.scale(game_surface, (WINDOW_WIDTH, WINDOW_HEIGHT))
+                window.blit(mid_surface, [0, 0])
+
+
 
             window.blit(fps_text, (0,0))
 


### PR DESCRIPTION
Aright according to the documentation:

> An optional destination surface can be passed which is faster than creating a new Surface. This destination surface must have the scaled dimensions (width * factor, height * factor) and same depth and format as the source Surface.

and this is exactly the problem on my device. I don't know what is the cause, but it's probably related to this warning I'm getting lately after the distro upgrade:

```
 Warning: PyGame seems to be running through X11 on top of wayland, instead of wayland directly
  window = pygame.display.set_mode((WINDOW_WIDTH, WINDOW_HEIGHT))
```



